### PR TITLE
Update URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,9 @@ This is a list of resources for learning C programming in general, or something 
 * [Diving into concurrency: trying out mutexes and atomics][202]
 * [Introduction to OpenMP][207] (video)
 * [OpenMP tutorial][264] (for the OpenMP3 standard)
-* [memcpy vs memmove][205]
 * [MPI tutorial][265]
 * [Some unknown features or tricks in C language][374]
 * [The lost art of C structure packing][34]
-* [What a C programmer should know about memory][271]
 * [What every C programmer should know about undefined behaviour][275]
 
 #### Advanced ####
@@ -658,7 +656,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [18]: https://www.enlightenment.org?p=about%252Flibs
 [19]: http://www.tcl.tk/
 [21]: http://xforms-toolkit.org/
-[22]: http://www.sqlite.org/
+[22]: http://www.sqlite.org/index.html
 [23]: https://unqlite.org/
 [25]: https://mariadb.com/
 [26]: https://github.com/clibs/clib
@@ -742,7 +740,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [116]: http://bstring.sourceforge.net/
 [117]: http://troydhanson.github.io/uthash/
 [119]: https://www.enlightenment.org?p=about%252Fefl
-[120]: http://zserge.com/jsmn.html
+[120]: https://zserge.com
 [121]: https://www.postgresql.org/
 [123]: https://gstreamer.freedesktop.org/
 [124]: http://libevent.org/
@@ -819,7 +817,6 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [202]: https://jvns.ca/blog/2014/12/14/fun-with-threads/
 [203]: https://github.com/silentbicycle/socket99
 [204]: http://danluu.com/malloc-tutorial/
-[205]: https://www.tedunangst.com/flak/post/memcpy-vs-memmove
 [206]: https://blogs.oracle.com/ksplice/8-gdb-tricks-you-should-know
 [207]: https://www.youtube.com/playlist?list=PLLX-Q6B8xqZ8n8bwjGdzBJ25X2utwnoEG
 [208]: http://nethack4.org/blog/building-c.html
@@ -877,7 +874,6 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [267]: http://blog.pkh.me/p/20-templating-in-c.html
 [269]: https://github.com/AbsInt/CompCert
 [270]: https://github.com/docopt/docopt.c
-[271]: http://marek.vavrusa.com/c/memory/2015/02/20/memory/
 [272]: https://kukuruku.co/post/i-do-not-know-c/
 [273]: http://www.lysator.liu.se/c/pikestyle.html
 [274]: https://github.com/andlabs/qo
@@ -968,7 +964,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [370]: https://bitbucket.org/orx/orx
 [371]: https://github.com/zturtleman/spearmint
 [372]: https://github.com/andrewrk/libsoundio
-[374]: http://proprogramming.org/some-unknown-features-or-tricks-in-c-language/
+[374]: https://proprogramming.org/some-unknown-features-or-tricks-in-c-language/
 [376]: https://github.com/timonwong/libao
 [377]: https://github.com/camgunz/cmp
 [378]: https://github.com/ludocode/mpack
@@ -1082,9 +1078,8 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [LIC42]: http://unlicense.org/
 [LIC43]: https://github.com/vim-syntastic/syntastic/blob/master/LICENCE
 [LIC44]: https://directory.fsf.org/wiki/License:BSD_4Clause
-[LIC45]: https://github.com/jgm/CommonMark/blob/master/LICENSE
+[LIC45]: https://github.com/commonmark/CommonMark/blob/master/LICENSE
 [LIC46]: https://github.com/libgit2/libgit2/blob/master/COPYING
 [LIC47]: http://troydhanson.github.io/uthash/license.html
 [LIC48]: https://tldrlegal.com/license/q-public-license-1.0-(qpl-1.0)#summary
 [LIC49]: https://directory.fsf.org/wiki/License:BSD_2Clause
-

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ These are tools to automate the building and testing of projects in C.
 * [GCC][40] - Provides a C compiler as part of its compiler set. Supports C11 and OpenMP. [[GNU GPL3][LIC1] or later]
 * [PCC][74] - Venerable C compiler. Supports C99. [[Various free licenses][LIC8]]
 * [TCC][58] - Tiny C Compiler; a small, fast C compiler. Supports C99 (except complex types). [[GNU LGPL2.1][LIC9] only]
-* [Intel SPMD][452] - Compiler for a variant of the C language, for single program, multiple data programming 
+* [Intel SPMD][452] - Compiler for a variant of the C language, for single program, multiple data programming
 
 ## Compiler libraries ##
 
@@ -106,7 +106,7 @@ Libraries for use in compilers, interpreters, and low-level based projects.
 * [lzo][338] - Very fast data compression library. [[GNU GPL2.1][LIC7]]
 * [zlib][230] - Massively-spiffy yet delicately-unobtrusive compression library. [[3-clause BSD][LIC5]]
 * [bzip2][441] - Patent free, high quality data compressor. [[3-clause BSD][LIC5]]
-* [lz4][442] - Fast Compression algorithm. 
+* [lz4][442] - Fast Compression algorithm.
 * [snappy][443] - Fast compression library (implementation in C++, native bindings to C)
 * [zstd][445] - Fast real-time compression algorithm [[3-clause BSD][LIC5]]
 * [brotli][446] - Generic lossless compression algorithm based on LZ77, Huffman coding and 2nd order context modelling [[MIT][LIC18]]
@@ -324,9 +324,11 @@ This is a list of resources for learning C programming in general, or something 
 * [Diving into concurrency: trying out mutexes and atomics][202]
 * [Introduction to OpenMP][207] (video)
 * [OpenMP tutorial][264] (for the OpenMP3 standard)
+* [memcpy vs memmove][205]
 * [MPI tutorial][265]
 * [Some unknown features or tricks in C language][374]
 * [The lost art of C structure packing][34]
+* [What a C programmer should know about memory][271]
 * [What every C programmer should know about undefined behaviour][275]
 
 #### Advanced ####
@@ -740,7 +742,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [116]: http://bstring.sourceforge.net/
 [117]: http://troydhanson.github.io/uthash/
 [119]: https://www.enlightenment.org?p=about%252Fefl
-[120]: https://zserge.com
+[120]: https://zserge.com/jsmn.html
 [121]: https://www.postgresql.org/
 [123]: https://gstreamer.freedesktop.org/
 [124]: http://libevent.org/
@@ -817,6 +819,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [202]: https://jvns.ca/blog/2014/12/14/fun-with-threads/
 [203]: https://github.com/silentbicycle/socket99
 [204]: http://danluu.com/malloc-tutorial/
+[205]: https://web.archive.org/web/20170620131430/https://www.tedunangst.com/flak/post/memcpy-vs-memmove
 [206]: https://blogs.oracle.com/ksplice/8-gdb-tricks-you-should-know
 [207]: https://www.youtube.com/playlist?list=PLLX-Q6B8xqZ8n8bwjGdzBJ25X2utwnoEG
 [208]: http://nethack4.org/blog/building-c.html
@@ -874,6 +877,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [267]: http://blog.pkh.me/p/20-templating-in-c.html
 [269]: https://github.com/AbsInt/CompCert
 [270]: https://github.com/docopt/docopt.c
+[271]: http://marek.vavrusa.com/memory/
 [272]: https://kukuruku.co/post/i-do-not-know-c/
 [273]: http://www.lysator.liu.se/c/pikestyle.html
 [274]: https://github.com/andlabs/qo

--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ This is a 'catch-all' category for anything that doesn't fit well anywhere else.
 [LIC17]: https://www.gnu.org/licenses/old-licenses/fdl-1.1.html
 [LIC18]: https://raw.githubusercontent.com/atom/atom/master/LICENSE.md
 [LIC19]: https://directory.fsf.org/wiki/License:EPLv1.0
-[LIC20]: https://github.com/qtproject/qt-creator/blob/master/LICENSE.GPL3-EXCEPT
+[LIC20]: https://github.com/qt-creator/qt-creator/blob/master/LICENSE.GPL3-EXCEPT
 [LIC21]: https://github.com/aws/amazon-freertos/blob/master/LICENSE
 [LIC22]: http://www.chibios.org/dokuwiki/doku.php?id=chibios:licensing:start\
 [LIC23]: https://github.com/contiki-os/contiki/blob/master/LICENSE


### PR DESCRIPTION
Update URLs that have moved or gone 404.

## URLs Updated
[http://www.sqlite.org/](http://www.sqlite.org/) -> **302 TEMPORARY REDIRECT**  
[http://zserge.com/jsmn.html](http://zserge.com/jsmn.html) -> **301 MOVED PERMANENTLY**  
[https://www.tedunangst.com/flak/post/memcpy-vs-memmove](https://www.tedunangst.com/flak/post/memcpy-vs-memmove) -> **INVALID SSL CERTIFICATE**
[http://marek.vavrusa.com/c/memory/2015/02/20/memory/](http://marek.vavrusa.com/c/memory/2015/02/20/memory/) -> **404 NOT FOUND**  
[http://proprogramming.org/some-unknown-features-or-tricks-in-c-language/](http://proprogramming.org/some-unknown-features-or-tricks-in-c-language/) -> **301 MOVED PERMANENTLY**  
[https://github.com/qtproject/qt-creator/blob/master/LICENSE.GPL3-EXCEPT](https://github.com/qtproject/qt-creator/blob/master/LICENSE.GPL3-EXCEPT) -> **301 MOVED PERMANENTLY**  
[https://github.com/jgm/CommonMark/blob/master/LICENSE](https://github.com/jgm/CommonMark/blob/master/LICENSE) -> **301 MOVED PERMANENTLY**  
