### PR TITLE
Added libsagui

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Implementations of memory allocators for various systems and platforms.
 * [libhttpd](http://www.hughes.com.au/products/libhttpd/) - Library to add basic web server capabilities to an application or embedded device. [`GNU GPL2`](http://www.gnu.org/licenses/gpl.html)
 * [libidn](https://www.gnu.org/software/libidn/) - Implementation of the Stringprep, Punycode and IDNA specifications. [`GNU GPL3 or later`](http://www.gnu.org/licenses/gpl.html)
 * [libmicrohttpd](https://www.gnu.org/software/libmicrohttpd/) - Small C library that makes it easy to run an HTTP server as part of another application. [`GNU LGPL2.1 or later`](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+* [libsagui](https://risoflora.github.io/libsagui/) - An ideal C library to develop cross-platform HTTP servers. [`GNU LGPL3`](http://www.gnu.org/licenses/lgpl.html)
 * [libvldmail](https://github.com/dertuxmalwieder/libvldmail) - Your friendly e-mail address validation library. [`WTFPLv2`](http://www.wtfpl.net/txt/copying/)
 * [lwan](https://lwan.ws/) - Experimental, scalable, high-performance HTTP server. [`GNU GPL2.1`](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 * [mongoose](https://cesanta.com/) - Embedded web server for C. [`GNU GPL2.1`](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)


### PR DESCRIPTION
* [libsagui](https://risoflora.github.io/libsagui/) - An ideal C library to develop cross-platform HTTP servers. [`GNU LGPL3`](http://www.gnu.org/licenses/lgpl.html)