### PR TITLE
Add t1ha To Hashing Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ All hashing related libraries, cryptographic or not.
 * [xxHash](http://cyan4973.github.io/xxHash/) - Extremely fast non-cryptographic hash algorithm. [`2-clause BSD`](https://directory.fsf.org/wiki/License:BSD-2-Clause)
 * [libcrc](https://github.com/PeterScott/murmur3) - Multi platform CRC library. [`MIT`](https://raw.githubusercontent.com/atom/atom/master/LICENSE.md)
 * [murmur](https://github.com/ispc/ispc) - C implementation of MurMur Hashing. [`Public Domain`](https://creativecommons.org/share-your-work/public-domain/)
+* [t1ha](https://github.com/leo-yuriev/t1ha) - Fast Positive Hash library. [`zlib`](https://directory.fsf.org/wiki/License:Zlib)
 
 ## Image Processing ##
 


### PR DESCRIPTION
Since this issue has been inactive for awhile, I've created the PR. Added [t1ha](https://github.com/leo-yuriev/t1ha) to the Hashing category, under the [`zlib`](https://directory.fsf.org/wiki/License:Zlib) license. Proposed in issue #105 