### PR TITLE
Fixed links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ All hashing related libraries, cryptographic or not.
 
 * [jwHash](https://github.com/watmough/jwHash) - Fast hashtable implementation. [`Apache 2.0`](https://directory.fsf.org/wiki/License:Apache-2.0)
 * [xxHash](http://cyan4973.github.io/xxHash/) - Extremely fast non-cryptographic hash algorithm. [`2-clause BSD`](https://directory.fsf.org/wiki/License:BSD-2-Clause)
-* [libcrc](https://github.com/PeterScott/murmur3) - Multi platform CRC library. [`MIT`](https://raw.githubusercontent.com/atom/atom/master/LICENSE.md)
-* [murmur](https://github.com/ispc/ispc) - C implementation of MurMur Hashing. [`Public Domain`](https://creativecommons.org/share-your-work/public-domain/)
+* [libcrc](https://www.libcrc.org/) - Multi platform CRC library. [`MIT`](https://raw.githubusercontent.com/atom/atom/master/LICENSE.md)
+* [murmur](https://github.com/PeterScott/murmur3) - C implementation of MurMur Hashing. [`Public Domain`](https://creativecommons.org/share-your-work/public-domain/)
 * [t1ha](https://github.com/leo-yuriev/t1ha) - Fast Positive Hash library. [`zlib`](https://directory.fsf.org/wiki/License:Zlib)
 
 ## Image Processing ##


### PR DESCRIPTION
The murmur and libcrc links were accidental mixed up. I have fixed them and removed the link to the Intel SPMD compiler in the Hash section of the library because the Intel SPMD compiler is already mentioned in the Compiler section of the list.